### PR TITLE
Add support for 16kB page size in Android 15

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -21,6 +21,9 @@ add_library(argon2native SHARED ${argon2native_SOURCES})
 target_compile_options(argon2native PRIVATE)
 target_include_directories(argon2native PUBLIC ${argon2native_DIR})
 
+# Add support for 16kB page size for Android 15.
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "-Wl,-z,max-page-size=16384")
+
 #
 # JNI integration (argon2jni)
 #
@@ -38,3 +41,6 @@ target_compile_options(argon2jni PRIVATE)
 target_include_directories(argon2jni PUBLIC ${argon2jni_DIR})
 
 target_link_libraries(argon2jni argon2native)
+
+# Add support for 16kB page size for Android 15.
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE "-Wl,-z,max-page-size=16384")


### PR DESCRIPTION
Android 15 adds support for 16kB page size instead of 4kB.

Because of that all native libraries need to be recompiled with special flags and libraries need to publish a new version with the recompiled native code.

https://developer.android.com/about/versions/15/behavior-changes-all#16-kb

https://developer.android.com/guide/practices/page-sizes

Tested on Android emulator with 16kB page size and with the alignment check script from the documentation.

```
./libargon2native.so: ALIGNED (2**14)
./libargon2jni.so: ALIGNED (2**14)
```